### PR TITLE
Set report_on_exception = false in join_nowait thread

### DIFF
--- a/lib/thwait.rb
+++ b/lib/thwait.rb
@@ -89,6 +89,7 @@ class ThreadsWait
     @threads.concat threads
     for th in threads
       Thread.start(th) do |t|
+        Thread.current.report_on_exception = false
         begin
           t.join
         ensure


### PR DESCRIPTION
Otherwise, duplicate exception reports can happen.

Fixes Ruby Bug 15644