### PR TITLE
Add explicit dependency to e2mmap

### DIFF
--- a/thwait.gemspec
+++ b/thwait.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "e2mmap"
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
e2mmap is no longer bundled to ruby-2.7.0.