### PR TITLE
gemspec: Distribute lib/, README, LICENSE

### DIFF
--- a/thwait.gemspec
+++ b/thwait.gemspec
@@ -16,9 +16,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/ruby/thwait"
   spec.license       = "BSD-2-Clause"
 
-  spec.files         = [".gitignore", "Gemfile", "LICENSE.txt", "README.md", "Rakefile", "bin/console", "bin/setup", "lib/thwait.rb", "lib/thwait/version.rb", "thwait.gemspec"]
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.files         = Dir["lib/**/*.rb", "LICENSE.txt", "README.md"]
   spec.require_paths = ["lib"]
 
   spec.add_dependency "e2mmap"


### PR DESCRIPTION
This PR reduces the amount of files shipped with the gem.

This gem exposes 0 executables, so we drop those directives, too.